### PR TITLE
Add missing parentheses for Package-Requires

### DIFF
--- a/dired-gitignore.el
+++ b/dired-gitignore.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/johannes-mueller/dired-gitignore.el
 ;; Version: 0.1.0
 ;; Keywords: dired, convenience, git
-;; Package-Requires: ((emacs "27.1")
+;; Package-Requires: ((emacs "27.1"))
 
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Currently `Package-Requires` of [dired-gitignore.el](https://github.com/johannes-mueller/dired-gitignore.el/blob/master/dired-gitignore.el#L9) is missing closing parentheses.
This would cause problem when using with [elpaca](https://github.com/progfolio/elpaca.git).

This PR add the missing parentheses in `Package-Requires` section.