### PR TITLE
Improve modeline lighter

### DIFF
--- a/dired-gitignore.el
+++ b/dired-gitignore.el
@@ -41,7 +41,7 @@
 (define-minor-mode dired-gitignore-mode
   "Toggle `dired-gitignore-mode'."
   :init-value nil
-  :lighter " !."
+  :lighter " !g"
   :group 'dired
   (if dired-gitignore-mode
       (add-hook 'dired-after-readin-hook #'dired-gitignore--hide)


### PR DESCRIPTION
The modeline lighter for `dired-gitignore` is the same as the one used by `dired-hide-dotfiles`. This is confusing in a couple of ways:

- You see `!.` in the modeline, but you don't know what's being hidden.
- If you have both modes enabled, the modeline reads `!. !.` 

This PR changes the default lighter. My suggestion is `!g`, for "not gitignored".